### PR TITLE
Babel yellow info after successfully compiled @babel/plugin fix

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+    "plugins": [
+      "@babel/plugin-proposal-private-property-in-object"
+    ]
+  }

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+    plugins: [
+      "@babel/plugin-proposal-private-property-in-object"
+    ]
+  };

--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.16.0"
   }
 }


### PR DESCRIPTION
After # Compiled successfully!
and after #webpack compiled successfully

Fixing this yellow info 
One of your dependencies, babel-preset-react-app, is importing the
"@babel/plugin-proposal-private-property-in-object" package without
declaring it in its dependencies. This is currently working because
"@babel/plugin-proposal-private-property-in-object" is already in your
node_modules folder for unrelated reasons, but it may break at any time.

babel-preset-react-app is part of the create-react-app project, which
is not maintianed anymore. It is thus unlikely that this bug will
ever be fixed. Add "@babel/plugin-proposal-private-property-in-object" to
your devDependencies to work around this error. This will make this message
go away.